### PR TITLE
Add support for powershell 2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,13 +31,13 @@ after_build:
       Push-AppveyorArtifact $n.FullName -DeploymentName Nupkg
 
 test_script:
-  - ps: .\tests\install.ps1
-  - ps: .\tests\run-meteor-version.ps1
-  - ps: .\tests\uninstall.ps1
+  - ps: powershell.exe -version 2 .\tests\install.ps1
+  - ps: powershell.exe -version 2 .\tests\run-meteor-version.ps1
+  - ps: powershell.exe -version 2 .\tests\uninstall.ps1
   # Make sure that it's no longer installed.
   - ps: If (.\tests\run-meteor-version.ps1) { throw }
   # Try another release, using the '/Release:x.y.z' flag.
-  - ps: .\tests\install.ps1 -ReleaseVersion 1.6-rc.15
+  - ps: powershell.exe -version 2 .\tests\install.ps1 -ReleaseVersion 1.6-rc.15
   - ps: If (!(.\tests\run-meteor-version.ps1 -Eq '1.6-rc.15')) { throw }
   - ps: |
       meteor create --release 1.6-rc.15 test-other-release

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,4 @@
 Write-Host "Ensuring 'build' directory exists..." -ForegroundColor Magenta
-$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $buildDirectory = Join-Path $PSScriptRoot 'build'
 New-Item -Type Directory -Force $buildDirectory
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,5 @@
 Write-Host "Ensuring 'build' directory exists..." -ForegroundColor Magenta
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $buildDirectory = Join-Path $PSScriptRoot 'build'
 New-Item -Type Directory -Force $buildDirectory
 

--- a/tests/install.ps1
+++ b/tests/install.ps1
@@ -5,7 +5,8 @@ Param(
 Write-Host "Installing chocolatey-core extensions..." -ForegroundColor Magenta
 & choco.exe install chocolatey-core.extension
 
-$checkoutDirectory = (Get-Item $PSScriptRoot).parent.FullName
+$testsDirectory = Split-Path $MyInvocation.MyCommand.Path -Parent
+$checkoutDirectory = (Get-Item $testsDirectory).parent.FullName
 $buildDirectory = Join-Path $checkoutDirectory 'build'
 
 # Trying to install the package we just made.

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -26,10 +26,10 @@ Initialize-MeteorDataDirectory
 # can simply be placed in the tools directory.  It must match the
 # pattern we're looking for and exist, otherwise we'll just download it.
 $gciTarGzArgs = @{
-  'path'    = $toolsDir
-  'filter'  = 'meteor-bootstrap-os.windows.*.tar.gz'
+  path    = $toolsDir
+  filter  = 'meteor-bootstrap-os.windows.*.tar.gz'
 }
-$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
+$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Select -First 1
 $bootstrapTarGzPath = Join-Path $toolsDir $bootstrapTarGzFileName
 
 # If we find it locally, we'll extract it from there, but otherwise
@@ -64,7 +64,7 @@ $gciTarArgs = @{
   path    = $installerTempDir
   filter  = 'meteor-bootstrap-os.windows.*.tar'
 }
-$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
+$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Select -First 1
 $bootstrapTarPath = Join-Path $installerTempDir $bootstrapTarFileName
 
 # Stop if for whatever reason, we failed to find the tarball.

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -28,9 +28,8 @@ Initialize-MeteorDataDirectory
 $gciTarGzArgs = @{
   'path'    = $toolsDir
   'filter'  = 'meteor-bootstrap-os.windows.*.tar.gz'
-  'file'    = $true
 }
-$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Select -First 1
+$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
 $bootstrapTarGzPath = Join-Path $toolsDir $bootstrapTarGzFileName
 
 # If we find it locally, we'll extract it from there, but otherwise
@@ -64,9 +63,8 @@ if (Test-Path -LiteralPath $bootstrapTarGzPath -PathType 'Leaf') {
 $gciTarArgs = @{
   path    = $installerTempDir
   filter  = 'meteor-bootstrap-os.windows.*.tar'
-  file    = $true
 }
-$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Select -First 1
+$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
 $bootstrapTarPath = Join-Path $installerTempDir $bootstrapTarFileName
 
 # Stop if for whatever reason, we failed to find the tarball.


### PR DESCRIPTION
Main change was to Get-ChildItem usage, based off changes recommended on https://stackoverflow.com/questions/37481335/return-only-files-with-get-childitem-in-powershell-2

I've tested on Windows 7 and installation was successful.

Refs: https://github.com/meteor/meteor-chocolatey-installer/issues/3