### PR TITLE
Release 0.0.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Meteor Chocolatey Installer Changelog
 
+## 0.0.2, TBD
+
+* Support for PowerShell 2.0 by using older CmdLet syntax, enabling the
+  installer to work on Windows Vista (and other older Windows releases).
+  [PR #4](https://github.com/meteor/meteor-chocolatey-installer/pull/4)
+  ([@dhulme](https://github.com/dhulme))
+
 ## 0.0.1, 2017-10-19
 
 * Initial release of the Chocolatey `meteor` package which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Meteor Chocolatey Installer Changelog
+
+## 0.0.1, 2017-10-19
+
+* Initial release of the Chocolatey `meteor` package which
+  implements similar (and better) functionality to the previous
+  generation InstallMeteor.exe, which is no longer maintained.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,69 @@
+# Meteor Project Code of Conduct
+
+### Community and Diversity
+
+We want to build a productive, happy and agile community that welcomes new ideas, constantly looks for areas to improve, and fosters collaboration. 
+
+The project gains strength from a diversity of backgrounds and perspectives in our contributor community, and we actively seek participation from those who enhance it. This code of conduct exists to lay some ground rules that ensure we can collaborate and communicate effectively, despite our diversity. The code applies equally to founders, team members and those seeking help and guidance.
+
+### Using This Code
+
+This isn’t an exhaustive list of things that you can’t do. Rather, it’s a guide for participation in the community that outlines how each of us can work to keep Meteor a positive, successful, and growing project. 
+
+This code of conduct applies to all spaces managed by the Meteor project or company. This includes Slack, GitHub issues, and any other forums created by the Meteor team which the community uses for communication. Breaches of this code outside these spaces may affect a person's ability to participate within them. We expect it to be honored by everyone who represents or participates in the project, whether officially or informally.
+
+If you believe someone is violating the code of conduct, please report it by emailing [community@meteor.com](mailto:community@meteor.com). 
+
+### We Strive To:
+
+- **Be open, patient, and welcoming**
+
+    Members of this community are open to collaboration, whether it's on PRs, issues, or problems. We're receptive to constructive comment and criticism, as we value what the experiences and skill sets of contributors bring to the project. We're accepting of all who wish to get involved, and find ways for anyone to participate in a way that best matches their strengths.
+  
+- **Be considerate**
+
+    We are considerate of our peers: other Meteor users and contributors. We’re thoughtful when addressing others’ efforts, keeping in mind that work is often undertaken for the benefit of the community. We also value others’ time and appreciate that not every issue or comment will be responded to immediately. We strive to be mindful in our communications, whether in person or online, and we're tactful when approaching views that are different from our own.
+    
+- **Be respectful**
+
+    As a community of professionals, we are professional in our handling of disagreements, and don’t allow frustration to turn into a personal attack. We work together to resolve conflict, assume good intentions and do our best to act in an empathic fashion. 
+
+    We do not tolerate harassment or exclusionary behavior. This includes, but is not limited to:
+  - Violent threats or language directed against another person.
+  - Discriminatory jokes and language.
+  - Posting sexually explicit or sexualized content.
+  - Posting content depicting or encouraging violence. 
+  - Posting (or threatening to post) other people's personally identifying information ("doxing").
+  - Personal insults, especially those using racist or sexist terms.
+  - Unwelcome sexual attention.
+  - Advocating for, or encouraging, any of the above behavior.
+  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+  
+- **Take responsibility for our words and our actions**
+
+    We can all make mistakes; when we do, we take responsibility for them. If someone has been harmed or offended, we listen carefully and respectfully. We are also considerate of others’ attempts to amend their mistakes.
+    
+- **Be collaborative**  
+
+    The work we produce is (and is part of) an ecosystem containing several parallel efforts working towards a similar goal. Collaboration between teams and individuals that each have their own goal and vision is essential to reduce redundancy and improve the quality of our work. 
+    
+    Internally and externally, we celebrate good collaboration. Wherever possible, we work closely with upstream projects and others in the free software community to coordinate our efforts. We prefer to work transparently and involve interested parties as early as possible.
+    
+- **Ask for help when in doubt**
+
+    Nobody is expected to be perfect in this community. Asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful.
+    
+- **Take initiative** 
+
+    We encourage new participants to feel empowered to lead, to take action, and to experiment when they feel innovation could improve the project. If we have an idea for a new tool, or how an existing tool can be improved, we speak up and take ownership of that work when possible. 
+    
+### Attribution
+
+Sections of this Code of Conduct were inspired in by the following Codes from other open source projects and resources we admire:  
+
+- [The Contributor Covenant](http://contributor-covenant.org/version/1/4/)
+- [Python](https://www.python.org/psf/codeofconduct/)
+- [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct)
+- [Django](https://www.djangoproject.com/conduct/)
+
+*This Meteor Code of Conduct is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/) license. This Code was last updated on August 28, 2017.* 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-present Meteor Development Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,7 +22,7 @@ The `devel` branch is used for active development, including pull requests.  Off
 To build the `.nupkg` from the `.nuspec`, use `choco pack` with the `meteor.nuspec` found at the root of this repository.
 
 ```ps1
-C:\> choco pack meteor.nuspec --outputdirectory path/to/build-output
+C:\> choco pack meteor.nuspec --outputdirectory C:\path\to\build-output
 ```
 
 ### Testing
@@ -38,8 +38,10 @@ We use [AppVeyor](https://appveyor.com/) to automatically test the installer on 
 This is best performed in a VirtualBox or other disposable environment.
 
 ```ps1
-C:\> choco install -force -yes meteor --pre --source path/to/build-output
+C:\> choco install -force -yes meteor --pre --source "'C:\\path\\to\\build-output;https://chocolatey.org/api/v2/'"
 ```
+
+> **Note:** The escape characters in the `--source` path are important!
 
 ### Publishing
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,39 +1,56 @@
 ﻿# Meteor Chocolatey Installer
 
-# 🍫  + ☄
+<h2>(Windows Only)</h2>
 
-## Building
+## Usage
+
+The installer is available on [Chocolatey](https://chocolatey.org/) (a Windows package manager), using the [`meteor` package](https://chocolatey.org/packages/meteor).  Please consult that repository for specific details, but the general idea is:
+
+```ps1
+C:\> choco install meteor
+```
+
+## Development
+This section is about making modifications, testing and publishing the Chocolatey `meteor` package itself, not for general Meteor development.  For more on Meteor, please see [Meteor on GitHub](https://github.com/meteor/meteor/).
+
+### Branches
+
+The `devel` branch is used for active development, including pull requests.  Official releases should be merged to the `master` branch.
+
+### Building
 
 To build the `.nupkg` from the `.nuspec`, use `choco pack` with the `meteor.nuspec` found at the root of this repository.
 
 ```ps1
-PS> choco pack meteor.nuspec --outputdirectory path/to/build-output
+C:\> choco pack meteor.nuspec --outputdirectory path/to/build-output
 ```
 
-## Testing
+### Testing
+
+#### Automatically
+
+We use [AppVeyor](https://appveyor.com/) to automatically test the installer on actual Windows hardware.  Any push to this repository will automatically kick off tests which build and install Meteor in an isolated environment, using the current installer.
+
+> **Note:** Git "tags" pushed to this repository which are prefixed with `release/`, will trigger publishing of the Chocolatey package if the testing is successful.  Please see the [Publishing](#Publishing) section below for more information.
+
+#### Locally
 
 This is best performed in a VirtualBox or other disposable environment.
 
 ```ps1
-PS> choco install -fy meteor --pre --source path/to/build-output
+C:\> choco install -force -yes meteor --pre --source path/to/build-output
 ```
 
-> `-f` is to force the install and `-y` is to answer "yes" to prompts.
+### Publishing
 
-## Publishing
+#### Automatically
 
-### Clear Comments before publishing.
+Any tag pushed to this repository in the format of `release/x.y.z` will automatically be published to Chocolatey after passing automated testing.  Only collaborators with push access to this repository can kick off this process.
 
-It's not clear to me if we need to do this, as I think the idea is to remove a lot of the irrelevant guiding information provided in the `choco new` boilerplate, but leaving this helpful command here for now.
+> Note: Releases can also be suffixed with `-beta-#` or `-rc-#` suffixes!
+#### Manually
 
+The above release process is preferred as it will force the package to go through automated testing, however the `choco push` can still be done manually when in posssession of the Chocolatey publishing key.
 ```ps1
-# IMPORTANT: Before releasing this package, copy/paste the next 2 lines into PowerShell to remove all comments from this file:
-#   $f='c:\path\to\thisFile.ps1'
-#   gc $f | ? {$_ -notmatch "^\s*#"} | % {$_ -replace '(^.*?)\s*?[^``]#.*','$1'} | Out-File $f+".~" -en utf8; mv -fo $f+".~" $f
-```
-
-### Publish
-
-```ps1
-PS> choco push build-output\meteor.<version>.nupkg --source 'https://push.chocolatey.org/' --key '<api-key>'
+C:\> choco push build-output\meteor.<version>.nupkg --source 'https://push.chocolatey.org/' --key '<api-key>'
 ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,6 +10,8 @@ The installer is available on [Chocolatey](https://chocolatey.org/) (a Windows p
 C:\> choco install meteor
 ```
 
+> **Note:** This will only work for the latest published package.  When trying to install a package which is pre-release (or not yet approved by Chocolatey moderators), it is necessary to pass the explicit version.  For example: `choco install meteor --version 0.0.1`.
+
 ## Development
 This section is about making modifications, testing and publishing the Chocolatey `meteor` package itself, not for general Meteor development.  For more on Meteor, please see [Meteor on GitHub](https://github.com/meteor/meteor/).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,10 @@ test_script:
   - ps: .\tests\run-meteor.ps1
   - ps: .\tests\uninstall.ps1
   # Make sure that it's no longer installed.
-  - ps: If ((.\tests\run-meteor.ps1)) { throw }
+  - ps: If (.\tests\run-meteor.ps1) { throw }
+  # Try another version.
+  - ps: .\tests\install.ps1 -ReleaseVersion 1.6-rc.15
+  - ps: If (!(.\tests\run-meteor.ps1 -Eq '1.6-rc.15')) { throw }
 
 before_deploy:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,6 @@ after_build:
 test_script:
   - ps: .\tests\install.ps1
   - ps: .\tests\run-meteor-version.ps1
-  - ps: |
-      meteor create test-default-meteor
-      cd test-default-meteor
-      meteor build ..\
   - ps: .\tests\uninstall.ps1
   # Make sure that it's no longer installed.
   - ps: If (.\tests\run-meteor-version.ps1) { throw }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,13 +32,13 @@ after_build:
 
 test_script:
   - ps: .\tests\install.ps1
-  - ps: .\tests\run-meteor.ps1
+  - ps: .\tests\run-meteor-version.ps1
   - ps: .\tests\uninstall.ps1
   # Make sure that it's no longer installed.
-  - ps: If (.\tests\run-meteor.ps1) { throw }
+  - ps: If (.\tests\run-meteor-version.ps1) { throw }
   # Try another version.
   - ps: .\tests\install.ps1 -ReleaseVersion 1.6-rc.15
-  - ps: If (!(.\tests\run-meteor.ps1 -Eq '1.6-rc.15')) { throw }
+  - ps: If (!(.\tests\run-meteor-version.ps1 -Eq '1.6-rc.15')) { throw }
 
 before_deploy:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,13 +31,13 @@ after_build:
       Push-AppveyorArtifact $n.FullName -DeploymentName Nupkg
 
 test_script:
-  - ps: .\tests\install.ps1
-  - ps: .\tests\run-meteor-version.ps1
-  - ps: .\tests\uninstall.ps1
+  - ps: powershell.exe -version 2 .\tests\install.ps1
+  - ps: powershell.exe -version 2 .\tests\run-meteor-version.ps1
+  - ps: powershell.exe -version 2 .\tests\uninstall.ps1
   # Make sure that it's no longer installed.
   - ps: If (.\tests\run-meteor-version.ps1) { throw }
   # Try another release, using the '/Release:x.y.z' flag.
-  - ps: .\tests\install.ps1 -ReleaseVersion 1.6-rc.15
+  - ps: powershell.exe -version 2 .\tests\install.ps1 -ReleaseVersion 1.6-rc.15
   - ps: If (!(.\tests\run-meteor-version.ps1 -Eq '1.6-rc.15')) { throw }
   - ps: |
       meteor create --release 1.6-rc.15 test-other-release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ skip_branch_with_pr: true
 
 image: Visual Studio 2015
 
+environment:
+  CHOCOLATEY_PACKAGE_NAME: meteor
+
 platform:
   - x64
   - x86
@@ -24,7 +27,8 @@ after_build:
   - ps: |
       $n = Get-ChildItem -Path .\build\ -Filter *.nupkg | Select-Object -First 1
       If (!$n) { throw "Missing nupkg." }
-      Push-AppveyorArtifact $n.FullName -DeploymentName Chocolatey
+      Push-AppveyorArtifact ".\$($env:CHOCOLATEY_PACKAGE_NAME).nuspec" -DeploymentName Nuspec
+      Push-AppveyorArtifact $n.FullName -DeploymentName Nupkg
 
 test_script:
   - ps: .\tests\install.ps1
@@ -33,10 +37,41 @@ test_script:
   # Make sure that it's no longer installed.
   - ps: If ((.\tests\run-meteor.ps1)) { throw }
 
+before_deploy:
+  - ps: |
+      if (!($artifacts.Nuspec)) {
+        throw "Missing Nuspec artifact."
+      }
+
+      if (!($artifacts.Nupkg)) {
+        throw "Missing Nupkg artifact."
+      }
+
+      $nuspec = Get-ChildItem $artifacts.Nuspec.path
+      $nupkg = Get-ChildItem $artifacts.Nupkg.path
+
+      # Get the version information out of the Nuspec
+      [xml]$nuspecXml = Get-Content -Path $nuspec.FullName
+      $packageId = $nuspecXml.package.metadata.id
+      $version = $nuspecXml.package.metadata.version
+
+      if ($packageId -ne $env:CHOCOLATEY_PACKAGE_NAME) {
+        throw "Wrong package 'id' in nuspec metadata! (${packageId})"
+      }
+
+      # Name of the nupkg artifact must match the metadata version.
+      if ($nupkg.Name -ne "${packageId}.${version}.nupkg") {
+        throw "Unexpected .nupkg filename $($nupkg.Name)"
+      }
+
+      If ($env:APPVEYOR_REPO_TAG_NAME -ne "release/${version}") {
+        throw "$($nupkg.Name) 'version' doesn't match the Git tag!"
+      }
+
 deploy:
   - provider: Environment
     name: Chocolatey
-    artifact: /^meteor.*\.nupkg/
+    artifact: Nupkg
     on:
       appveyor_repo_tag: true
       appveyor_repo_tag_name: /^release\/([0-9]+\.){2,3}[0-9]+(-(beta|rc)-[0-9]+)?$/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,12 +33,20 @@ after_build:
 test_script:
   - ps: .\tests\install.ps1
   - ps: .\tests\run-meteor-version.ps1
+  - ps: |
+      meteor create test-default-meteor
+      cd test-default-meteor
+      meteor build ..\
   - ps: .\tests\uninstall.ps1
   # Make sure that it's no longer installed.
   - ps: If (.\tests\run-meteor-version.ps1) { throw }
-  # Try another version.
+  # Try another release, using the '/Release:x.y.z' flag.
   - ps: .\tests\install.ps1 -ReleaseVersion 1.6-rc.15
   - ps: If (!(.\tests\run-meteor-version.ps1 -Eq '1.6-rc.15')) { throw }
+  - ps: |
+      meteor create --release 1.6-rc.15 test-other-release
+      cd test-other-release
+      meteor build ..\
 
 before_deploy:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ after_build:
   - ps: |
       $n = Get-ChildItem -Path .\build\ -Filter *.nupkg | Select-Object -First 1
       If (!$n) { throw "Missing nupkg." }
-      Push-AppveyorArtifact $n.FullName -DeploymentName chocolatey
+      Push-AppveyorArtifact $n.FullName -DeploymentName Chocolatey
 
 test_script:
   - ps: .\tests\install.ps1
@@ -34,14 +34,10 @@ test_script:
   - ps: If ((.\tests\run-meteor.ps1)) { throw }
 
 deploy:
-  - provider: NuGet
-    name: chocolatey
-    server: https://push.chocolatey.org/
-    api_key:
-      # This is encrypted with https://ci.appveyor.com/tools/encrypt.
-      secure: RBCK168BKPpK9Kky65YFXVpQYl5YFIJ/+Lk4Ka+nZmJZX6aFbMD+fJI+arYMOhEF
-    skip_symbols: true
+  - provider: Environment
+    name: Chocolatey
     artifact: /^meteor.*\.nupkg/
     on:
-      branch: master
+      appveyor_repo_tag: true
+      appveyor_repo_tag_name: /^release\/([0-9]+\.){2,3}[0-9]+(-(beta|rc)-[0-9]+)?$/
       platform: x64

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,4 @@
 Write-Host "Ensuring 'build' directory exists..." -ForegroundColor Magenta
-$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $buildDirectory = Join-Path $PSScriptRoot 'build'
 New-Item -Type Directory -Force $buildDirectory
 

--- a/build.ps1
+++ b/build.ps1
@@ -4,18 +4,10 @@ New-Item -Type Directory -Force $buildDirectory
 
 $nuspecFile = Join-Path $PSScriptRoot 'meteor.nuspec'
 
-# Get the version information out of this file.
-[xml]$nuspec = Get-Content -Path $nuspecFile
-$testPackageId = $nuspec.package.metadata.id
-$testVersion = $nuspec.package.metadata.version
-
 Write-Host "Installing chocolatey-core extensions..." -ForegroundColor Magenta
 & choco.exe install chocolatey-core.extension
 
 Write-Host "Running 'choco pack' for ${testVersion}..." -ForegroundColor Magenta
 & choco.exe pack $nuspecFile --outputdirectory $buildDirectory
-
-$nupkgFile = "${testPackageId}.${testVersion}.nupkg"
-$nupkgPath = Join-Path $buildDirectory $nupkgFile
 
 Get-ChildItem $buildDirectory

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,5 @@
 Write-Host "Ensuring 'build' directory exists..." -ForegroundColor Magenta
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $buildDirectory = Join-Path $PSScriptRoot 'build'
 New-Item -Type Directory -Force $buildDirectory
 

--- a/meteor.nuspec
+++ b/meteor.nuspec
@@ -4,7 +4,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>meteor</id>
-    <version>0.0.2-beta-2</version>
+    <version>0.0.2</version>
     <packageSourceUrl>https://github.com/meteor/meteor-chocolatey-installer/</packageSourceUrl>
     <owners>Meteor Development Group, Inc.</owners>
     <title>Meteor</title>

--- a/meteor.nuspec
+++ b/meteor.nuspec
@@ -4,7 +4,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>meteor</id>
-    <version>0.0.2-beta-1</version>
+    <version>0.0.2-beta-2</version>
     <packageSourceUrl>https://github.com/meteor/meteor-chocolatey-installer/</packageSourceUrl>
     <owners>Meteor Development Group, Inc.</owners>
     <title>Meteor</title>

--- a/meteor.nuspec
+++ b/meteor.nuspec
@@ -19,6 +19,7 @@
     <bugTrackerUrl>https://github.com/meteor/meteor/issues</bugTrackerUrl>
     <tags>meteor</tags>
     <summary>Meteor, the JavaScript App Platform</summary>
+    <releaseNotes>https://github.com/meteor/meteor-chocolatey-installer/blob/master/CHANGELOG.md</releaseNotes>
     <description>
 Meteor is an ultra-simple environment for building modern web
 applications.

--- a/meteor.nuspec
+++ b/meteor.nuspec
@@ -4,7 +4,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>meteor</id>
-    <version>0.0.1</version>
+    <version>0.0.2-beta-1</version>
     <packageSourceUrl>https://github.com/meteor/meteor-chocolatey-installer/</packageSourceUrl>
     <owners>Meteor Development Group, Inc.</owners>
     <title>Meteor</title>

--- a/tests/install.ps1
+++ b/tests/install.ps1
@@ -23,11 +23,13 @@ Write-Host "Trying to install $($nupkg.FullName)..." `
 If ($releaseVersion) {
   & choco.exe install meteor --force --yes -d `
     --allow-downgrade `
+    --prerelease `
     --source $buildDirectory `
     --params="'/Release:${releaseVersion}'"
 } Else {
   & choco.exe install meteor --force --yes -d `
     --allow-downgrade `
+    --prerelease `
     --source $buildDirectory
 }
 

--- a/tests/install.ps1
+++ b/tests/install.ps1
@@ -1,8 +1,16 @@
+Param(
+  [string]$releaseVersion
+)
+
 Write-Host "Installing chocolatey-core extensions..." -ForegroundColor Magenta
 & choco.exe install chocolatey-core.extension
 
+$checkoutDirectory = (Get-Item $PSScriptRoot).parent.FullName
+$buildDirectory = Join-Path $checkoutDirectory 'build'
+
 # Trying to install the package we just made.
-$nupkg = Get-ChildItem -Path .\build\ -Filter '*.nupkg' | Select-Object -First 1
+$nupkg = Get-ChildItem -Path $buildDirectory -Filter '*.nupkg' |
+  Select-Object -First 1
 
 If (!(Test-Path -PathType 'Leaf' -Path $nupkg.FullName)) {
   throw "Couldn't find the '.nupkg'.  It should be the only file in '.\build'!"
@@ -10,4 +18,16 @@ If (!(Test-Path -PathType 'Leaf' -Path $nupkg.FullName)) {
 
 Write-Host "Trying to install $($nupkg.FullName)..." `
   -ForegroundColor Magenta
-& choco.exe install -fdy --allow-downgrade $nupkg.FullName
+
+If ($releaseVersion) {
+  & choco.exe install meteor --force --yes -d `
+    --allow-downgrade `
+    --source $buildDirectory `
+    --params="'/RELEASE:${releaseVersion}'"
+} Else {
+  & choco.exe install meteor --force --yes -d `
+    --allow-downgrade `
+    --source $buildDirectory
+}
+
+Write-Host "The result was '$result'"

--- a/tests/install.ps1
+++ b/tests/install.ps1
@@ -23,7 +23,7 @@ If ($releaseVersion) {
   & choco.exe install meteor --force --yes -d `
     --allow-downgrade `
     --source $buildDirectory `
-    --params="'/RELEASE:${releaseVersion}'"
+    --params="'/Release:${releaseVersion}'"
 } Else {
   & choco.exe install meteor --force --yes -d `
     --allow-downgrade `

--- a/tests/install.ps1
+++ b/tests/install.ps1
@@ -5,7 +5,8 @@ Param(
 Write-Host "Installing chocolatey-core extensions..." -ForegroundColor Magenta
 & choco.exe install chocolatey-core.extension
 
-$checkoutDirectory = (Get-Item $PSScriptRoot).parent.FullName
+$testsDirectory = Split-Path $MyInvocation.MyCommand.Path -Parent
+$checkoutDirectory = (Get-Item $testsDirectory).parent.FullName
 $buildDirectory = Join-Path $checkoutDirectory 'build'
 
 # Trying to install the package we just made.

--- a/tests/run-meteor-version.ps1
+++ b/tests/run-meteor-version.ps1
@@ -12,15 +12,15 @@ $env:Path += ";${meteorDir}"
 Write-Host "Running 'meteor --version'..." -ForegroundColor Magenta
 # Try calling it!
 try {
-  & "meteor" --version
+  $result = (& "meteor" --version)
   $meteorExitCode = $LASTEXITCODE
 } catch {
   # Nothing means it worked.
 }
 
-Write-Host "The Meteor Exit Code was $meteorExitCode"
-
 # If there was an error, Exit 1.
 If ($meteorExitCode -ne 0) {
   Exit 1
 }
+
+$result -Replace '^Meteor '

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -26,10 +26,10 @@ Initialize-MeteorDataDirectory
 # can simply be placed in the tools directory.  It must match the
 # pattern we're looking for and exist, otherwise we'll just download it.
 $gciTarGzArgs = @{
-  'path'    = $toolsDir
-  'filter'  = 'meteor-bootstrap-os.windows.*.tar.gz'
+  path    = $toolsDir
+  filter  = 'meteor-bootstrap-os.windows.*.tar.gz'
 }
-$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
+$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Select -First 1
 $bootstrapTarGzPath = Join-Path $toolsDir $bootstrapTarGzFileName
 
 # If we find it locally, we'll extract it from there, but otherwise
@@ -64,7 +64,7 @@ $gciTarArgs = @{
   path    = $installerTempDir
   filter  = 'meteor-bootstrap-os.windows.*.tar'
 }
-$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
+$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Select -First 1
 $bootstrapTarPath = Join-Path $installerTempDir $bootstrapTarFileName
 
 # Stop if for whatever reason, we failed to find the tarball.

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -28,9 +28,8 @@ Initialize-MeteorDataDirectory
 $gciTarGzArgs = @{
   'path'    = $toolsDir
   'filter'  = 'meteor-bootstrap-os.windows.*.tar.gz'
-  'file'    = $true
 }
-$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Select -First 1
+$bootstrapTarGzFileName = Get-ChildItem @gciTarGzArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
 $bootstrapTarGzPath = Join-Path $toolsDir $bootstrapTarGzFileName
 
 # If we find it locally, we'll extract it from there, but otherwise
@@ -64,9 +63,8 @@ if (Test-Path -LiteralPath $bootstrapTarGzPath -PathType 'Leaf') {
 $gciTarArgs = @{
   path    = $installerTempDir
   filter  = 'meteor-bootstrap-os.windows.*.tar'
-  file    = $true
 }
-$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Select -First 1
+$bootstrapTarFileName = Get-ChildItem @gciTarArgs | Where-Object { !$_.PSIsContainer } | Select -First 1
 $bootstrapTarPath = Join-Path $installerTempDir $bootstrapTarFileName
 
 # Stop if for whatever reason, we failed to find the tarball.

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -44,10 +44,10 @@ if (Test-Path -LiteralPath $bootstrapTarGzPath -PathType 'Leaf') {
 } else {
   $bootstrapQueryString32 = New-BootstrapLinkQueryString `
     -Arch 'os.windows.x86_32' `
-    -Release $packageParameters.RELEASE
+    -Release $packageParameters.Release
   $bootstrapQueryString64 = New-BootstrapLinkQueryString `
     -Arch 'os.windows.x86_64' `
-    -Release $packageParameters.RELEASE
+    -Release $packageParameters.Release
   $installTarGzArgs = @{
     packageName   = $env:ChocolateyPackageName
     url           = "${bootstrapLinkUrl}${bootstrapQueryString32}"


### PR DESCRIPTION
## 0.0.2, TBD

* Support for PowerShell 2.0 by using older CmdLet syntax, enabling the
  installer to work on Windows Vista (and other older Windows releases).
  [PR #4](https://github.com/meteor/meteor-chocolatey-installer/pull/4)
  ([@dhulme](https://github.com/dhulme))