### PR TITLE
#308 - Fix problems on Windows installation

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -41,15 +41,11 @@ if (Test-Path -LiteralPath $bootstrapTarGzPath -PathType 'Leaf') {
   }
   Get-ChocolateyUnzip @unzipLocalTarGzArgs
 } else {
-  $bootstrapQueryString32 = New-BootstrapLinkQueryString `
-    -Arch 'os.windows.x86_32' `
-    -Release $packageParameters.Release
   $bootstrapQueryString64 = New-BootstrapLinkQueryString `
     -Arch 'os.windows.x86_64' `
     -Release $packageParameters.Release
   $installTarGzArgs = @{
     packageName   = $env:ChocolateyPackageName
-    url           = "${bootstrapLinkUrl}${bootstrapQueryString32}"
     url64bit      = "${bootstrapLinkUrl}${bootstrapQueryString64}"
     unzipLocation = $installerTempDir
   }


### PR DESCRIPTION
Since version 1.10.1 we stop support to systems 32-bit (https://github.com/meteor/meteor/blob/devel/History.md#v1101-2020-03-12), but our installer on Windows (Chocolatey) was still trying to download the 32-bit version, and for that,  the users ended up with an error saying that was not possible download Meteor. The solution was simply to stop providing a 32-bit URL to Chocolatey.