### PR TITLE
Remove 32 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Meteor Chocolatey Installer Changelog
 
+## 0.0.3, 2019-05-22
+
+* Since version 1.10.1 we stop support to systems 32-bit (https://github.com/meteor/meteor/blob/devel/History.md#v1101-2020-03-12), but our installer on Windows (Chocolatey) was still trying to download the 32-bit version, and for that, the users ended up with an error saying that was not possible download Meteor. Now Chocolatey shouldn't try to download the 32-bit Meteor version.
+
 ## 0.0.2, 2017-11-23
 
 * Support for PowerShell 2.0 by using older CmdLet syntax, enabling the

--- a/meteor.nuspec
+++ b/meteor.nuspec
@@ -4,7 +4,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>meteor</id>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <packageSourceUrl>https://github.com/meteor/meteor-chocolatey-installer/</packageSourceUrl>
     <owners>Meteor Development Group, Inc.</owners>
     <title>Meteor</title>


### PR DESCRIPTION
To deploy a new release, the release version must match with the meteor.nuspec version. Also, I'm adding the change to the changelog.